### PR TITLE
Release 0.1.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def read(filename):
 
 setup(
     name="sf_apm_lib",
-    version="0.1.4",
+    version="0.1.5",
     url="https://github.com/snappyflow/py_snappyflow",
     license='MIT',
 

--- a/sf_apm_lib/snappyflow.py
+++ b/sf_apm_lib/snappyflow.py
@@ -10,7 +10,6 @@ from yaml.loader import SafeLoader
 
 class Snappyflow:
     def __init__(self):
-        self.__CP_ENCRYPTED_KEY = "U25hcHB5RmxvdzEyMzQ1Ng=="
         self.project_name = None
         self.app_name = None
         self.profile_data = None
@@ -37,9 +36,10 @@ class Snappyflow:
         self.app_name = app_name
 
     def _get_profile_data(self, profile_key):
-        unpad = lambda s : s[0:-ord(s[-1:])]
 
-        key = base64.b64decode(self.__CP_ENCRYPTED_KEY)
+        unpad = lambda s : s[0:-ord(s[-1:])]
+        CP_ENCRYPTED_KEY = "U25hcHB5RmxvdzEyMzQ1Ng=="
+        key = base64.b64decode(CP_ENCRYPTED_KEY)
         
         enc = base64.b64decode(profile_key)
         iv = enc[:16]


### PR DESCRIPTION
**Issue**: Security Breach
**Root cause** : The CP_ENCRYPTED_KEY variable, being under the \_\_init\_\_() method, was accessible using the _Snappyflow_ instance.
**Changes made**: Moved the CP_ENCRYPTED_KEY declaration from the __init__ function to a private function (__get_profile_data_).
**Test cases executed**:

- Previously it was accessible using the _Snappyflow_ instance.

![image](https://github.com/snappyflow/py_snappyflow/assets/135809166/8ee84d39-ea20-4cb0-8005-64b5366197d4)

-After the changes, it is not accessible (raised AttributeError).

![image](https://github.com/snappyflow/py_snappyflow/assets/135809166/fd8c5a66-cf8e-41c1-9bd0-6616977fa75e)




