### PR TITLE
Release 0.1.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def read(filename):
 
 setup(
     name="sf_apm_lib",
-    version="0.1.5",
+    version="0.1.6",
     url="https://github.com/snappyflow/py_snappyflow",
     license='MIT',
 

--- a/sf_apm_lib/snappyflow.py
+++ b/sf_apm_lib/snappyflow.py
@@ -132,6 +132,8 @@ def end_transaction(elasticapm, client, request, response):
     """
     path_info = request.httprequest.environ.get("PATH_INFO")
     name = path_info
+    if not hasattr(request, 'params'):
+        request.params = {}
     for key in ["model", "method", "signal"]:
         val = request.params.get(key)
         if val and val not in name:


### PR DESCRIPTION
**Issue**:  Getting this error in logs when tracing enabled for odoo16 application

end_transaction(elasticapm, client, request, response)  # add before return response
  File "/home/isha/isha/sushumna_16/venv/lib/python3.7/site-packages/sf_apm_lib/snappyflow.py", line 136, in end_transaction
    val = request.params.get(key)
AttributeError: 'Request' object has no attribute 'params'

**Root cause**: As there is code to handle "**_if there is no params attribute in request attribute_**" case  in  **end_transaction**() 
we are getting this error.

**Changes made** : Added code in snappyflow.py end_transaction()  to handle if there is no params attribute in request attribute case.

**Testcases executed**:

Added changes locally
![image](https://github.com/snappyflow/py_snappyflow/assets/135809166/f38efa6f-6b9b-47cc-b555-9aa0064e0f94)

previously we are getting this error

![MicrosoftTeams-image (8)](https://github.com/snappyflow/py_snappyflow/assets/135809166/d6ffb1af-feab-410a-960d-f7a6d48b7755)

And after making changes its running without any errors

![image](https://github.com/snappyflow/py_snappyflow/assets/135809166/f78cc115-b8fe-4b84-8fe8-ec33c76dd7f1)

And getting traces successfully

![image](https://github.com/snappyflow/py_snappyflow/assets/135809166/015b26f5-95e0-47d0-8d60-eb717f5ff3b3)




